### PR TITLE
Android security 11.0.0 release 57

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**
+!**/src/test/**
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+
+### VS Code ###
+.vscode/

--- a/src/com/android/keychain/KeyChainActivity.java
+++ b/src/com/android/keychain/KeyChainActivity.java
@@ -416,7 +416,7 @@ public class KeyChainActivity extends Activity {
         Uri uri = getIntent().getParcelableExtra(KeyChain.EXTRA_URI);
         if (uri != null) {
             String hostMessage = String.format(res.getString(R.string.requesting_server),
-                                               uri.getAuthority());
+                    Uri.encode(uri.getAuthority(), "$,;:@&=+"));
             if (contextMessage == null) {
                 contextMessage = hostMessage;
             } else {


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r57' of https://android.googlesource.com/platform/packages/apps/KeyChain into arrow-11.0

Android security 11.0.0 release 57
Tag: https://android.googlesource.com/platform/packages/apps/KeyChain/+/refs/tags/android-security-11.0.0_r57

Merge cherrypicks of [18281033] into security-aosp-rvc-release.

Change-Id: [I394aee0312d1412bfbd2f4fbe2c66e66fef26069](https://android-review.googlesource.com/#/q/I394aee0312d1412bfbd2f4fbe2c66e66fef26069)